### PR TITLE
Temporarily lock eslint dependency to 2.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "arrify": "^1.0.0",
     "babel-eslint": "^5.0.0",
     "deep-assign": "^2.0.0",
-    "eslint": "^2.1.0",
+    "eslint": "2.2.0",
     "eslint-config-marlint": "^1.5.0",
     "eslint-plugin-babel": "^3.1.0",
     "eslint-plugin-react": "^3.16.1",


### PR DESCRIPTION
https://github.com/babel/babel-eslint/issues/267
found by Imam